### PR TITLE
Add ElderHouse scene with door logic

### DIFF
--- a/src/GameDataManager.ts
+++ b/src/GameDataManager.ts
@@ -1,6 +1,14 @@
 export const gameData = {
   maps: {
-    // TODO: Add maps data from the original HTML game
+    elder_house: {
+      width: 10,
+      height: 8,
+      tileSize: 32,
+      scenery: [
+        { type: 'table', x: 4, y: 4 },
+        { type: 'door', x: 9, y: 7 }
+      ]
+    }
   },
   inspirationData: {
     // TODO: Add inspiration data from the original HTML game

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser'
-import GameScene from './GameScene'
+import ElderHouseScene from './scenes/ElderHouseScene'
+import WorldScene from './scenes/WorldScene'
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -13,7 +14,7 @@ const config: Phaser.Types.Core.GameConfig = {
       debug: false
     }
   },
-  scene: [GameScene]
+  scene: [ElderHouseScene, WorldScene]
 }
 
 export default new Phaser.Game(config)

--- a/src/scenes/ElderHouseScene.ts
+++ b/src/scenes/ElderHouseScene.ts
@@ -1,0 +1,75 @@
+import Phaser from 'phaser'
+import gameData from '../GameDataManager'
+
+export default class ElderHouseScene extends Phaser.Scene {
+  private player!: Phaser.GameObjects.Rectangle
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys
+  private interactKey!: Phaser.Input.Keyboard.Key
+  private door?: Phaser.GameObjects.Rectangle
+
+  constructor() {
+    super('elder-house')
+  }
+
+  preload() {}
+
+  create() {
+    const map = gameData.maps.elder_house
+    const tileSize = map.tileSize
+    const width = map.width * tileSize
+    const height = map.height * tileSize
+
+    this.cameras.main.setBounds(0, 0, width, height)
+    this.physics.world.setBounds(0, 0, width, height)
+
+    // simple floor
+    this.add.rectangle(width / 2, height / 2, width, height, 0x888888)
+
+    // create player
+    this.player = this.add.rectangle(tileSize * 2, tileSize * 6, tileSize, tileSize, 0x00ff00)
+    this.physics.add.existing(this.player)
+    const body = this.player.body as Phaser.Physics.Arcade.Body
+    body.setCollideWorldBounds(true)
+
+    // add scenery
+    map.scenery.forEach(obj => {
+      const x = obj.x * tileSize + tileSize / 2
+      const y = obj.y * tileSize + tileSize / 2
+      if (obj.type === 'table') {
+        this.add.rectangle(x, y, tileSize * 2, tileSize, 0x664422)
+      } else if (obj.type === 'door') {
+        const door = this.add.rectangle(x, y, tileSize, tileSize * 2, 0x222222)
+        this.physics.add.existing(door, true)
+        this.door = door
+      }
+    })
+
+    this.cursors = this.input.keyboard.createCursorKeys()
+    this.interactKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE)
+
+    this.cameras.main.startFollow(this.player)
+  }
+
+  update() {
+    const body = this.player.body as Phaser.Physics.Arcade.Body
+    body.setVelocity(0)
+
+    if (this.cursors.left?.isDown) {
+      body.setVelocityX(-150)
+    } else if (this.cursors.right?.isDown) {
+      body.setVelocityX(150)
+    }
+    if (this.cursors.up?.isDown) {
+      body.setVelocityY(-150)
+    } else if (this.cursors.down?.isDown) {
+      body.setVelocityY(150)
+    }
+
+    if (this.door) {
+      const dist = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.door.x, this.door.y)
+      if (dist < 40 && Phaser.Input.Keyboard.JustDown(this.interactKey)) {
+        this.scene.start('world')
+      }
+    }
+  }
+}

--- a/src/scenes/WorldScene.ts
+++ b/src/scenes/WorldScene.ts
@@ -1,0 +1,13 @@
+import Phaser from 'phaser'
+
+export default class WorldScene extends Phaser.Scene {
+  constructor() {
+    super('world')
+  }
+
+  preload() {}
+
+  create() {
+    this.add.text(200, 200, 'World Scene', { font: '20px Arial', color: '#ffffff' })
+  }
+}


### PR DESCRIPTION
## Summary
- add elder house map information
- create `ElderHouseScene` and `WorldScene`
- update game config to use new scenes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f2b4d72d8832ea3f9941a8818b5a4