### PR TITLE
Implement elder riddle mechanic

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import Phaser from 'phaser'
-import ElderHouseScene from './scenes/ElderHouseScene'
+import CasaDoAnciaoScene from './scenes/CasaDoAnciaoScene'
+import UIScene from './scenes/UIScene'
+import VinhedoScene from './scenes/VinhedoScene'
 import WorldScene from './scenes/WorldScene'
 
 const config: Phaser.Types.Core.GameConfig = {
@@ -14,7 +16,7 @@ const config: Phaser.Types.Core.GameConfig = {
       debug: false
     }
   },
-  scene: [ElderHouseScene, WorldScene]
+  scene: [CasaDoAnciaoScene, UIScene, VinhedoScene, WorldScene]
 }
 
 export default new Phaser.Game(config)

--- a/src/scenes/CasaDoAnciaoScene.ts
+++ b/src/scenes/CasaDoAnciaoScene.ts
@@ -1,0 +1,103 @@
+import Phaser from 'phaser'
+import gameData from '../GameDataManager'
+
+export default class CasaDoAnciaoScene extends Phaser.Scene {
+  private player!: Phaser.GameObjects.Rectangle
+  private npc!: Phaser.GameObjects.Rectangle
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys
+  private interactKey!: Phaser.Input.Keyboard.Key
+  private newDoor?: Phaser.GameObjects.Rectangle
+  private uiScene!: Phaser.Scene
+
+  private npcData = {
+    question: 'Qual \u00e9 a palavra secreta?',
+    answer: 'esp\u00edrito',
+    successDialogue: 'Muito bem, jovem. A porta se abriu!'
+  }
+
+  constructor() {
+    super('casa-do-anciao')
+  }
+
+  preload() {}
+
+  create() {
+    const map = gameData.maps.elder_house
+    const tileSize = map.tileSize
+    const width = map.width * tileSize
+    const height = map.height * tileSize
+
+    this.cameras.main.setBounds(0, 0, width, height)
+    this.physics.world.setBounds(0, 0, width, height)
+
+    this.add.rectangle(width / 2, height / 2, width, height, 0x888888)
+
+    this.player = this.add.rectangle(tileSize * 2, tileSize * 6, tileSize, tileSize, 0x00ff00)
+    this.physics.add.existing(this.player)
+    const body = this.player.body as Phaser.Physics.Arcade.Body
+    body.setCollideWorldBounds(true)
+
+    this.npc = this.add.rectangle(tileSize * 5, tileSize * 3, tileSize, tileSize * 2, 0x5555ff)
+    this.physics.add.existing(this.npc, true)
+
+    map.scenery.forEach(obj => {
+      const x = obj.x * tileSize + tileSize / 2
+      const y = obj.y * tileSize + tileSize / 2
+      if (obj.type === 'table') {
+        this.add.rectangle(x, y, tileSize * 2, tileSize, 0x664422)
+      }
+    })
+
+    this.cursors = this.input.keyboard.createCursorKeys()
+    this.interactKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.E)
+
+    this.scene.launch('ui')
+    this.uiScene = this.scene.get('ui')
+    this.uiScene.events.on('submitAnswer', this.handleAnswer, this)
+
+    this.cameras.main.startFollow(this.player)
+  }
+
+  update() {
+    const body = this.player.body as Phaser.Physics.Arcade.Body
+    body.setVelocity(0)
+
+    if (this.cursors.left?.isDown) {
+      body.setVelocityX(-150)
+    } else if (this.cursors.right?.isDown) {
+      body.setVelocityX(150)
+    }
+    if (this.cursors.up?.isDown) {
+      body.setVelocityY(-150)
+    } else if (this.cursors.down?.isDown) {
+      body.setVelocityY(150)
+    }
+
+    const dist = Phaser.Math.Distance.Between(this.player.x, this.player.y, this.npc.x, this.npc.y)
+    if (dist < 50 && Phaser.Input.Keyboard.JustDown(this.interactKey)) {
+      this.uiScene.events.emit('showQuestion', this.npcData.question)
+    }
+  }
+
+  private handleAnswer(answer: string) {
+    if (answer.trim().toLowerCase() === this.npcData.answer) {
+      this.uiScene.events.emit('showSuccess', this.npcData.successDialogue)
+      this.time.delayedCall(3000, () => this.createDoor())
+    } else {
+      this.uiScene.events.emit('showGameOver')
+    }
+  }
+
+  private createDoor() {
+    if (this.newDoor) return
+    const map = gameData.maps.elder_house
+    const tileSize = map.tileSize
+    const x = tileSize * 1.5
+    const y = tileSize
+    this.newDoor = this.add.rectangle(x, y, tileSize, tileSize * 2, 0xf6e05e)
+    this.physics.add.existing(this.newDoor, true)
+    this.physics.add.overlap(this.player, this.newDoor, () => {
+      this.scene.start('vinhedo')
+    })
+  }
+}

--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -1,0 +1,103 @@
+import Phaser from 'phaser'
+
+export default class UIScene extends Phaser.Scene {
+  private questionText?: Phaser.GameObjects.Text
+  private inputText?: Phaser.GameObjects.Text
+  private successText?: Phaser.GameObjects.Text
+  private overlay?: Phaser.GameObjects.Rectangle
+  private gameOverContainer?: Phaser.GameObjects.Container
+  private currentAnswer = ''
+
+  constructor() {
+    super('ui')
+  }
+
+  create() {
+    this.events.on('showQuestion', this.showQuestion, this)
+    this.events.on('showSuccess', this.showSuccess, this)
+    this.events.on('showGameOver', this.showGameOver, this)
+
+    this.input.keyboard.on('keydown', (event: KeyboardEvent) => {
+      if (!this.inputText) return
+
+      if (event.key === 'Backspace') {
+        this.currentAnswer = this.currentAnswer.slice(0, -1)
+      } else if (event.key === 'Enter') {
+        this.events.emit('submitAnswer', this.currentAnswer)
+        this.clearQuestion()
+      } else if (event.key.length === 1) {
+        this.currentAnswer += event.key
+      }
+      this.inputText.setText(this.currentAnswer)
+    })
+  }
+
+  private showQuestion(question: string) {
+    this.clearAll()
+    this.questionText = this.add.text(400, 200, question, {
+      font: '20px Arial',
+      color: '#ffffff',
+      backgroundColor: '#000000'
+    }).setOrigin(0.5)
+
+    this.inputText = this.add.text(400, 260, '', {
+      font: '18px Arial',
+      color: '#ffff00',
+      backgroundColor: '#000000'
+    }).setOrigin(0.5)
+    this.currentAnswer = ''
+  }
+
+  private clearQuestion() {
+    this.questionText?.destroy()
+    this.inputText?.destroy()
+    this.questionText = undefined
+    this.inputText = undefined
+    this.currentAnswer = ''
+  }
+
+  private showSuccess(text: string) {
+    this.clearAll()
+    this.successText = this.add.text(400, 200, text, {
+      font: '20px Arial',
+      color: '#00ff00',
+      backgroundColor: '#000000'
+    }).setOrigin(0.5)
+    this.time.delayedCall(3000, () => {
+      this.successText?.destroy()
+      this.successText = undefined
+    })
+  }
+
+  private showGameOver() {
+    this.clearAll()
+    this.overlay = this.add.rectangle(400, 300, 800, 600, 0x000000, 0.7)
+    this.gameOverContainer = this.add.container(400, 300)
+    const txt = this.add.text(0, -20, 'Game Over', {
+      font: '32px Arial',
+      color: '#ff0000'
+    }).setOrigin(0.5)
+    const btn = this.add.text(0, 30, 'Reiniciar', {
+      font: '20px Arial',
+      color: '#ffffff',
+      backgroundColor: '#000000'
+    }).setPadding(10).setOrigin(0.5).setInteractive()
+    btn.on('pointerdown', () => {
+      const scene = this.scene.get('casa-do-anciao')
+      scene.scene.restart()
+      this.scene.restart()
+    })
+    this.gameOverContainer.add([txt, btn])
+  }
+
+  private clearAll() {
+    this.clearQuestion()
+    this.successText?.destroy()
+    this.successText = undefined
+    this.overlay?.destroy()
+    if (this.gameOverContainer) {
+      this.gameOverContainer.destroy(true)
+      this.gameOverContainer = undefined
+    }
+  }
+}

--- a/src/scenes/VinhedoScene.ts
+++ b/src/scenes/VinhedoScene.ts
@@ -1,0 +1,13 @@
+import Phaser from 'phaser'
+
+export default class VinhedoScene extends Phaser.Scene {
+  constructor() {
+    super('vinhedo')
+  }
+
+  preload() {}
+
+  create() {
+    this.add.text(200, 200, 'VinhedoScene', { font: '20px Arial', color: '#ffffff' })
+  }
+}


### PR DESCRIPTION
## Summary
- add CasaDoAnciaoScene with riddle logic
- create UIScene to display question UI and game over overlay
- create VinhedoScene placeholder
- wire new scenes in main.ts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f3099f70c832eb551bd61eb5e90b8