### PR TITLE
Fix GameScene startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import PreloadScene from './scenes/PreloadScene'
 import UIScene from './scenes/UIScene'
 import VinhedoScene from './scenes/VinhedoScene'
 import WorldScene from './scenes/WorldScene'
+import GameScene from './GameScene'
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -17,7 +18,7 @@ const config: Phaser.Types.Core.GameConfig = {
       debug: false
     }
   },
-  scene: [PreloadScene, CasaDoAnciaoScene, UIScene, VinhedoScene, WorldScene]
+  scene: [PreloadScene, GameScene, CasaDoAnciaoScene, UIScene, VinhedoScene, WorldScene]
 }
 
 export default new Phaser.Game(config)

--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -15,6 +15,6 @@ export default class PreloadScene extends Phaser.Scene {
   }
 
   create() {
-    this.scene.start('casa-do-anciao')
+    this.scene.start('game')
   }
 }


### PR DESCRIPTION
## Summary
- load GameScene after preload so the player sprite appears

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f73cb87b4832e818c851c8e44f7da