### PR TITLE
Fix idle frame logic

### DIFF
--- a/src/GameScene.ts
+++ b/src/GameScene.ts
@@ -84,6 +84,16 @@ export default class GameScene extends Phaser.Scene {
       this.player.anims.play('walk-left', true)
     } else {
       this.player.anims.stop()
+      const last = this.player.anims.currentAnim?.key
+      if (last === 'walk-down') {
+        this.player.setFrame(0)
+      } else if (last === 'walk-left') {
+        this.player.setFrame(4)
+      } else if (last === 'walk-right') {
+        this.player.setFrame(8)
+      } else if (last === 'walk-up') {
+        this.player.setFrame(12)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- preserve last facing direction in `GameScene` when player stops moving

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f796bc3e4832e9aee9049d8d0a785