### PR TITLE
Add house interior background

### DIFF
--- a/src/GameScene.ts
+++ b/src/GameScene.ts
@@ -17,8 +17,21 @@ export default class GameScene extends Phaser.Scene {
   }
 
   create() {
-    this.player = this.physics.add.sprite(100, 100, 'player_sprite')
+    const width = this.scale.width
+    const height = this.scale.height
+
+    this.cameras.main.setBounds(0, 0, width, height)
+    this.physics.world.setBounds(0, 0, width, height)
+
+    this.add.tileSprite(width / 2, height / 2, width, height, 'base')
+
+    this.player = this.physics.add.sprite(width / 2, height / 2, 'player_sprite')
     this.player.setCollideWorldBounds(true)
+
+    // simple furniture
+    this.add.rectangle(width / 2, height - 40, 64, 64, 0x222222)
+    this.add.rectangle(width / 2 - 100, height / 2 + 50, 80, 40, 0x664422)
+    this.add.rectangle(width / 2 + 100, height / 2 + 50, 80, 40, 0x664422)
 
     this.cursors = this.input.keyboard.createCursorKeys()
 


### PR DESCRIPTION
## Summary
- set camera bounds and add floor tiles to GameScene
- place simple door and tables as furniture

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f7a9b9e48832e9254d597e9d90a48