### PR TITLE
Update house interior with inside-house image

### DIFF
--- a/src/GameScene.ts
+++ b/src/GameScene.ts
@@ -17,21 +17,18 @@ export default class GameScene extends Phaser.Scene {
   }
 
   create() {
-    const width = this.scale.width
-    const height = this.scale.height
+    const width = 240
+    const height = 160
 
     this.cameras.main.setBounds(0, 0, width, height)
     this.physics.world.setBounds(0, 0, width, height)
 
-    this.add.tileSprite(width / 2, height / 2, width, height, 'base')
+    this.add.image(width / 2, height / 2, 'inside-house')
 
     this.player = this.physics.add.sprite(width / 2, height / 2, 'player_sprite')
     this.player.setCollideWorldBounds(true)
 
-    // simple furniture
-    this.add.rectangle(width / 2, height - 40, 64, 64, 0x222222)
-    this.add.rectangle(width / 2 - 100, height / 2 + 50, 80, 40, 0x664422)
-    this.add.rectangle(width / 2 + 100, height / 2 + 50, 80, 40, 0x664422)
+    // interior dimensions match the inside-house image
 
     this.cursors = this.input.keyboard.createCursorKeys()
 

--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -12,6 +12,7 @@ export default class PreloadScene extends Phaser.Scene {
       frameWidth: 32,
       frameHeight: 32
     })
+    this.load.image('inside-house', 'inside-house.png')
     this.load.image('house', 'House.png')
     this.load.image('tiles', 'Tiles.png')
     this.load.image('tree', 'Tree.png')


### PR DESCRIPTION
## Summary
- preload `inside-house.png` asset
- use `inside-house.png` as the house interior background
- set world size to match the `inside-house` image

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f7dbb1384832e9f62134d40253081